### PR TITLE
feat(fetch): add `Response.json` static method

### DIFF
--- a/.changeset/big-hounds-sniff.md
+++ b/.changeset/big-hounds-sniff.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/web-fetch": patch
+---
+
+add Response.json static method

--- a/packages/fetch/src/response.js
+++ b/packages/fetch/src/response.js
@@ -12,13 +12,13 @@ const INTERNALS = Symbol('Response internals');
 
 /**
  * Response class
- * 
+ *
  * @typedef {Object} Ext
  * @property {number} [size]
  * @property {string} [url]
  * @property {number} [counter]
  * @property {number} [highWaterMark]
- * 
+ *
  * @implements {globalThis.Response}
  */
 export default class Response extends Body {
@@ -123,6 +123,23 @@ export default class Response extends Body {
 				location: new URL(url).toString()
 			},
 			status
+		});
+	}
+
+	/**
+	 * @param {any} data The URL that the new response is to originate from.
+	 * @param {ResponseInit} [responseInit] An optional status code for the response (e.g., 302.)
+	 * @returns {Response} A Response object.
+	 */
+	static json(data, responseInit = {}) {
+		let headers = new Headers(responseInit.headers);
+		if (!headers.has("Content-Type")) {
+			headers.set("Content-Type", "application/json; charset=utf-8");
+		}
+
+		return new Response(JSON.stringify(data), {
+			...responseInit,
+			headers,
 		});
 	}
 

--- a/packages/fetch/src/response.js
+++ b/packages/fetch/src/response.js
@@ -128,9 +128,9 @@ export default class Response extends Body {
 
 	/**
 	 * @template {unknown} Data
-	 * @param {Data} data The URL that the new response is to originate from.
+	 * @param {Data} data The data to be converted into a JSON string.
 	 * @param {ResponseInit} [responseInit] An optional status code for the response (e.g., 302.)
-	 * @returns {Promise<Data>} A Response object.
+	 * @returns {TypedResponse<Data>} A Response object.
 	 */
 	static json(data, responseInit = {}) {
 		let headers = new Headers(responseInit.headers);
@@ -159,3 +159,9 @@ Object.defineProperties(Response.prototype, {
 	clone: {enumerable: true}
 });
 
+/**
+ * @typedef {Omit<Response, "json"> & {
+ *   json(): Promise<T>;
+ * }} TypedResponse
+ * @template T
+ */

--- a/packages/fetch/src/response.js
+++ b/packages/fetch/src/response.js
@@ -127,9 +127,10 @@ export default class Response extends Body {
 	}
 
 	/**
-	 * @param {any} data The URL that the new response is to originate from.
+	 * @template {unknown} Data
+	 * @param {Data} data The URL that the new response is to originate from.
 	 * @param {ResponseInit} [responseInit] An optional status code for the response (e.g., 302.)
-	 * @returns {Response} A Response object.
+	 * @returns {Promise<Data>} A Response object.
 	 */
 	static json(data, responseInit = {}) {
 		let headers = new Headers(responseInit.headers);

--- a/packages/fetch/src/response.js
+++ b/packages/fetch/src/response.js
@@ -19,6 +19,11 @@ const INTERNALS = Symbol('Response internals');
  * @property {number} [counter]
  * @property {number} [highWaterMark]
  *
+ * @typedef {Omit<Response, "json"> & {
+ *   json(): Promise<T>;
+ * }} TypedResponse
+ * @template T
+ *
  * @implements {globalThis.Response}
  */
 export default class Response extends Body {
@@ -158,10 +163,3 @@ Object.defineProperties(Response.prototype, {
 	headers: {enumerable: true},
 	clone: {enumerable: true}
 });
-
-/**
- * @typedef {Omit<Response, "json"> & {
- *   json(): Promise<T>;
- * }} TypedResponse
- * @template T
- */

--- a/packages/fetch/test/response.js
+++ b/packages/fetch/test/response.js
@@ -220,6 +220,21 @@ describe('Response', () => {
 		const res = new Response();
 		expect(res.url).to.equal('');
 	});
+
+	it('should support json static method', () => {
+		const res = Response.json({a: 1});
+		return res.json().then(result => {
+			expect(result.a).to.equal(1);
+		});
+	})
+
+	it('should support json static method with added responseInit', () => {
+		const res = Response.json({a: 1}, { headers: { "x-foo": "bar" } });
+		expect(res.headers.get('x-foo')).to.equal('bar');
+		return res.json().then(result => {
+			expect(result.a).to.equal(1);
+		});
+	})
 });
 
 const streamFromString = text => new ReadableStream({


### PR DESCRIPTION
https://github.com/remix-run/remix/discussions/3308

======================================================================================

confirmed working with `npm link` and importing Response from `@remix-run/web-fetch`

![image](https://github.com/remix-run/web-std-io/assets/11698668/d052e9d3-e6cb-4045-899e-90c09b294fc1)
