### PR TITLE
fix: demote browser export

### DIFF
--- a/.changeset/funny-dolls-drop.md
+++ b/.changeset/funny-dolls-drop.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/web-fetch": patch
+---
+
+Prefer require, import and types exports over browser export

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -9,9 +9,9 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/src/lib.node.d.ts",
       "require": "./dist/lib.node.cjs",
       "import": "./src/lib.node.js",
-      "types": "./dist/src/lib.node.d.ts",
       "browser": "./src/lib.js"
     },
     "./package.json": "./package.json",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -9,10 +9,10 @@
   "type": "module",
   "exports": {
     ".": {
-      "browser": "./src/lib.js",
       "require": "./dist/lib.node.cjs",
       "import": "./src/lib.node.js",
-      "types": "./dist/src/lib.node.d.ts"
+      "types": "./dist/src/lib.node.d.ts",
+      "browser": "./src/lib.js"
     },
     "./package.json": "./package.json",
     "./body": {


### PR DESCRIPTION
Prefer require, import and types exports over browser.

Exports are resolved in order, i.e. the first match is used.

I'm not sure why the browser export is using the raw src, however when Jest is configured with `testEnvironment: "jsdom"`, it will resolve to this file causing 2 issues:

- Jest will not transpile it unless added to transformIgnorePatterns or [experimental ESM modules support](https://jestjs.io/docs/ecmascript-modules) is enabled
- Jest throws a type error as discussed on https://github.com/remix-run/remix/issues/3402



Also:

> "types" - can be used by typing systems to resolve the typing file for the given export. This condition should always be included first.
https://nodejs.org/api/packages.html

