### PR TITLE
Fix generated types to work with pure esm

### DIFF
--- a/.changeset/electro-disco.md
+++ b/.changeset/electro-disco.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/web-fetch": patch
+---
+
+Fix generated types to work with node ESM / NodeNext

--- a/packages/fetch/src/fetch.js
+++ b/packages/fetch/src/fetch.js
@@ -32,9 +32,9 @@ const supportedSchemas = new Set(['data:', 'http:', 'https:', 'file:']);
 /**
  * Fetch function
  *
- * @param   {string | URL | import('./request').default} url - Absolute url or Request instance
+ * @param   {string | URL | import('./request.js').default} url - Absolute url or Request instance
  * @param   {RequestInit} [options_] - Fetch options
- * @return  {Promise<import('./response').default>}
+ * @return  {Promise<import('./response.js').default>}
  */
 async function fetch(url, options_ = {}) {
 	return new Promise((resolve, reject) => {
@@ -319,9 +319,9 @@ async function fetch(url, options_ = {}) {
 }
 
 /**
- * 
- * @param {import('http').ClientRequest} request 
- * @param {(error:Error) => void} errorCallback 
+ *
+ * @param {import('http').ClientRequest} request
+ * @param {(error:Error) => void} errorCallback
  */
 function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 	/** @type {import('net').Socket} */


### PR DESCRIPTION
The generated types from jsdoc need an explicit file extension for package to work with pure esm when nodenext is specified in tsconfig.

<img width="1191" alt="Screen Shot 2022-07-09 at 5 39 05 PM" src="https://user-images.githubusercontent.com/7049628/178124052-a4241d26-b59d-44f6-9612-0003ee229718.png">
