### PR TITLE
Memory leak when using keepAlive

### DIFF
--- a/.changeset/giant-taxis-breathe.md
+++ b/.changeset/giant-taxis-breathe.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/web-fetch": patch
+---
+
+Memory leak caused by unregistered listeners. Solution was copied from a node-fetch pr.

--- a/packages/fetch/src/fetch.js
+++ b/packages/fetch/src/fetch.js
@@ -346,6 +346,7 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 			}
 		};
 
+        /** @param {Buffer} buf */
 		const onData = buf => {
 			properLastChunkReceived = Buffer.compare(buf.slice(-5), LAST_CHUNK) === 0;
 

--- a/packages/fetch/src/fetch.js
+++ b/packages/fetch/src/fetch.js
@@ -346,7 +346,7 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 			}
 		};
 
-        /** @param {Buffer} buf */
+		/** @param {Buffer} buf */
 		const onData = buf => {
 			properLastChunkReceived = Buffer.compare(buf.slice(-5), LAST_CHUNK) === 0;
 
@@ -361,7 +361,7 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 			previousChunk = buf;
 		};
 
-        socket.prependListener('close', onSocketClose);
+		socket.prependListener('close', onSocketClose);
 		socket.on('data', onData);
 
 		request.on('close', () => {

--- a/packages/fetch/src/fetch.js
+++ b/packages/fetch/src/fetch.js
@@ -346,13 +346,7 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 			}
 		};
 
-		socket.prependListener('close', onSocketClose);
-
-		request.on('abort', () => {
-			socket.removeListener('close', onSocketClose);
-		});
-
-		socket.on('data', buf => {
+		const onData = buf => {
 			properLastChunkReceived = Buffer.compare(buf.slice(-5), LAST_CHUNK) === 0;
 
 			// Sometimes final 0-length chunk and end of message code are in separate packets
@@ -364,6 +358,14 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 			}
 
 			previousChunk = buf;
+		};
+
+        socket.prependListener('close', onSocketClose);
+		socket.on('data', onData);
+
+		request.on('close', () => {
+			socket.removeListener('close', onSocketClose);
+			socket.removeListener('data', onData);
 		});
 	});
 }


### PR DESCRIPTION
This is a direct copy of https://github.com/node-fetch/node-fetch/pull/1474. 

We're having memory leak issues as we're using a http agent with `keepAlive` options with the fetch used on the remix server.