### PR TITLE
fix: empty filename should not be treated as string

### DIFF
--- a/.changeset/light-snails-leave.md
+++ b/.changeset/light-snails-leave.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/web-fetch": patch
+---
+
+If you create a FormData object on the browser with empty file input, a default empty file entry (i.e. new File([], '')) would be generated. However, this is currently presented as an empty string instead when you read it on the server. This should fix the discrepancy.

--- a/packages/fetch/src/utils/form-data.js
+++ b/packages/fetch/src/utils/form-data.js
@@ -109,7 +109,7 @@ export const toFormData = async (source) => {
       } else if (typeof filename !== 'undefined') {
         form.append(name, new File([], '', { type: contentType }))
       } else {
-	    form.append(name, new TextDecoder().decode(data), filename)
+        form.append(name, new TextDecoder().decode(data), filename)
       }
     }
     return form

--- a/packages/fetch/src/utils/form-data.js
+++ b/packages/fetch/src/utils/form-data.js
@@ -104,7 +104,7 @@ export const toFormData = async (source) => {
     const form = new FormData()
     const parts = iterateMultipart(body, boundary)
     for await (const { name, data, filename, contentType } of parts) {
-      if (filename) {
+      if (typeof filename !== 'undefined') {
         form.append(name, new File([data], filename, { type: contentType }))
       } else {
         form.append(name, new TextDecoder().decode(data), filename)

--- a/packages/fetch/src/utils/form-data.js
+++ b/packages/fetch/src/utils/form-data.js
@@ -89,31 +89,31 @@ export function getFormDataLength(form, boundary) {
  * @param {Body & {headers?:Headers}} source
  */
 export const toFormData = async (source) => {
-	let { body, headers } = source;
-	const contentType = headers?.get('Content-Type') || ''
+  let { body, headers } = source;
+  const contentType = headers?.get('Content-Type') || ''
 
-	if (contentType.startsWith('application/x-www-form-urlencoded') && body != null) {
+  if (contentType.startsWith('application/x-www-form-urlencoded') && body != null) {
 		const form = new FormData();
 		let bodyText = await source.text();
 		new URLSearchParams(bodyText).forEach((v, k) => form.append(k, v));
 		return form;
-	}
+  }
 
-	const [type, boundary] = contentType.split(/\s*;\s*boundary=/)
-	if (type === 'multipart/form-data' && boundary != null && body != null) {
-		const form = new FormData()
-		const parts = iterateMultipart(body, boundary)
-		for await (const { name, data, filename, contentType } of parts) {
-			if (typeof filename === 'string') {
-				form.append(name, new File([data], filename, { type: contentType }))
-			} else if (typeof filename !== 'undefined') {
-				form.append(name, new File([], '', { type: contentType }))
-			} else {
-				form.append(name, new TextDecoder().decode(data), filename)
-			}
-		}
-		return form
-	} else {
-		throw new TypeError('Could not parse content as FormData.')
-	}
+  const [type, boundary] = contentType.split(/\s*;\s*boundary=/)
+  if (type === 'multipart/form-data' && boundary != null && body != null) {
+    const form = new FormData()
+    const parts = iterateMultipart(body, boundary)
+    for await (const { name, data, filename, contentType } of parts) {
+      if (typeof filename === 'string') {
+        form.append(name, new File([data], filename, { type: contentType }))
+      } else if (typeof filename !== 'undefined') {
+        form.append(name, new File([], '', { type: contentType }))
+      } else {
+	    form.append(name, new TextDecoder().decode(data), filename)
+      }
+    }
+    return form
+  } else {
+    throw new TypeError('Could not parse content as FormData.')
+  }
 }

--- a/packages/fetch/test/request.js
+++ b/packages/fetch/test/request.js
@@ -338,7 +338,10 @@ describe('Request', () => {
 		ogFormData.append('a', 1);
 		ogFormData.append('b', 2);
 		ogFormData.append('file', new File(['content'], 'file.txt'));
-		ogFormData.append('empty-file', new File([], '', { type: 'application/octet-stream' }));
+
+		// This is what happens when you construct the form data set with an empty file input:
+		// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set
+		ogFormData.append('empty-input-file', new File([], '', { type: 'application/octet-stream' }));
 
 		const request = new Request(base, {
 			method: 'POST',
@@ -358,13 +361,13 @@ describe('Request', () => {
 			expect(file.size).to.equal(7);
 			expect(await file.text()).to.equal("content");
 			expect(file.lastModified).to.be.a('number');
-			const emptyFile = clonedFormData.get('empty-file');
-			if (typeof emptyFile !== "object") {
-				throw new Error("empty-file is not an object");
+			const emptyInputFile = clonedFormData.get('empty-input-file');
+			if (typeof emptyInputFile !== "object") {
+				throw new Error("emptyInputFile is not an object");
 			}
-			expect(emptyFile.name).to.equal("");
-			expect(emptyFile.type).to.equal("application/octet-stream");
-			expect(emptyFile.size).to.equal(0);
+			expect(emptyInputFile.name).to.equal("");
+			expect(emptyInputFile.type).to.equal("application/octet-stream");
+			expect(emptyInputFile.size).to.equal(0);
 		});
 	});
 

--- a/packages/fetch/test/request.js
+++ b/packages/fetch/test/request.js
@@ -362,9 +362,9 @@ describe('Request', () => {
 			if (typeof emptyFile !== "object") {
 				throw new Error("empty-file is not an object");
 			}
-			expect(file.name).to.equal("");
-			expect(file.type).to.equal("application/octet-stream");
-			expect(file.size).to.equal(0);
+			expect(emptyFile.name).to.equal("");
+			expect(emptyFile.type).to.equal("application/octet-stream");
+			expect(emptyFile.size).to.equal(0);
 		});
 	});
 

--- a/packages/fetch/test/request.js
+++ b/packages/fetch/test/request.js
@@ -339,10 +339,6 @@ describe('Request', () => {
 		ogFormData.append('b', 2);
 		ogFormData.append('file', new File(['content'], 'file.txt'));
 
-		// This is what happens when you construct the form data set with an empty file input:
-		// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set
-		ogFormData.append('empty-input-file', new File([], '', { type: 'application/octet-stream' }));
-
 		const request = new Request(base, {
 			method: 'POST',
 			body: ogFormData,
@@ -361,13 +357,6 @@ describe('Request', () => {
 			expect(file.size).to.equal(7);
 			expect(await file.text()).to.equal("content");
 			expect(file.lastModified).to.be.a('number');
-			const emptyInputFile = clonedFormData.get('empty-input-file');
-			if (typeof emptyInputFile !== "object") {
-				throw new Error("emptyInputFile is not an object");
-			}
-			expect(emptyInputFile.name).to.equal("");
-			expect(emptyInputFile.type).to.equal("application/octet-stream");
-			expect(emptyInputFile.size).to.equal(0);
 		});
 	});
 
@@ -396,5 +385,53 @@ describe('Request', () => {
 			expect(await file.text()).to.equal("content");
 			expect(file.lastModified).to.be.a('number');
 		});
+	});
+
+	it('should decode empty file inputs into File instances (web FormData)', async () => {
+		const ogFormData = new WebFormData();
+		ogFormData.append('a', 1);
+		// This is what happens when you construct the form data set with an empty file input:
+		// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set
+		ogFormData.append('file', new File([], '', { type: 'application/octet-stream' }));
+		const request = new Request(base, {
+			method: 'POST',
+			body: ogFormData,
+		});
+		const clonedRequest = request.clone();
+		return clonedRequest.formData().then(async clonedFormData => {
+			expect(clonedFormData.get('a')).to.equal("1");
+			const file = clonedFormData.get('file');
+			expect(file.name).to.equal("");
+			expect(file.type).to.equal("application/octet-stream");
+			expect(file.size).to.equal(0);
+		});
+	});
+
+	it.skip('should decode empty file inputs into File instances (node FormData)', async () => {
+		const ogFormData = new FormData();
+		ogFormData.append('a', 1);
+		// This is what happens when you construct the form data set with an empty file input:
+		// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set
+		ogFormData.append('file', Buffer.from(''), {
+			// Note: This doesn't work at the moment due to https://github.com/form-data/form-data/issues/412.
+			// There is a v4 released which has a fix that might handle this but I
+			// wasn't positive if it had breaking changes that would impact us so we
+			// can handle an upgrade separately.
+			filename: '',
+			contentType: 'application/octet-stream',
+		});
+		const request = new Request(base, {
+			method: 'POST',
+			body: ogFormData,
+		});
+		const clonedRequest = request.clone();
+		return clonedRequest.formData().then(async clonedFormData => {
+			expect(clonedFormData.get('a')).to.equal("1");
+			const file = clonedFormData.get('file');
+			expect(file.name).to.equal("");
+			expect(file.type).to.equal("application/octet-stream");
+			expect(file.size).to.equal(0);
+		});
+
 	});
 });

--- a/packages/fetch/test/request.js
+++ b/packages/fetch/test/request.js
@@ -338,6 +338,7 @@ describe('Request', () => {
 		ogFormData.append('a', 1);
 		ogFormData.append('b', 2);
 		ogFormData.append('file', new File(['content'], 'file.txt'));
+		ogFormData.append('empty-file', new File([], '', { type: 'application/octet-stream' }));
 
 		const request = new Request(base, {
 			method: 'POST',
@@ -357,6 +358,13 @@ describe('Request', () => {
 			expect(file.size).to.equal(7);
 			expect(await file.text()).to.equal("content");
 			expect(file.lastModified).to.be.a('number');
+			const emptyFile = clonedFormData.get('empty-file');
+			if (typeof emptyFile !== "object") {
+				throw new Error("empty-file is not an object");
+			}
+			expect(file.name).to.equal("");
+			expect(file.type).to.equal("application/octet-stream");
+			expect(file.size).to.equal(0);
 		});
 	});
 


### PR DESCRIPTION
If you create a FormData object on the browser with empty file input, a default empty file entry (i.e. `new File([], '')`) would be generated. However, this is presented as an empty string instead when you read it on the server.

You can test it [here](https://codesandbox.io/s/quizzical-tree-kyvddb?file=/app/routes/index.tsx).

I am not sure where to add this test. Let me know if you have any suggestion.