### PR TITLE
fix: export CJS version for browser

### DIFF
--- a/.changeset/afraid-coats-rescue.md
+++ b/.changeset/afraid-coats-rescue.md
@@ -1,0 +1,9 @@
+---
+"@remix-run/web-blob": patch
+"@remix-run/web-fetch": patch
+"@remix-run/web-file": patch
+"@remix-run/web-form-data": patch
+"@remix-run/web-stream": patch
+---
+
+Export CJS version for browser

--- a/.changeset/afraid-coats-rescue.md
+++ b/.changeset/afraid-coats-rescue.md
@@ -1,9 +1,9 @@
 ---
-"@remix-run/web-blob": patch
-"@remix-run/web-fetch": patch
-"@remix-run/web-file": patch
-"@remix-run/web-form-data": patch
-"@remix-run/web-stream": patch
+"@remix-run/web-blob": minor
+"@remix-run/web-fetch": minor
+"@remix-run/web-file": minor
+"@remix-run/web-form-data": minor
+"@remix-run/web-stream": minor
 ---
 
 Export CJS version for browser

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -19,7 +19,10 @@
   "exports": {
     ".": {
       "types": "./dist/src/lib.d.ts",
-      "browser": "./src/lib.js",
+      "browser": {
+        "require": "./dist/src/lib.cjs",
+        "import": "./src/lib.js"
+      },
       "require": "./dist/src/lib.node.cjs",
       "import": "./src/lib.node.js"
     }

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -10,7 +10,10 @@
   "exports": {
     ".": {
       "types": "./dist/src/lib.node.d.ts",
-      "browser": "./src/lib.js",
+      "browser": {
+        "require": "./dist/lib.cjs",
+        "import": "./src/lib.js"
+      },
       "require": "./dist/lib.node.cjs",
       "import": "./src/lib.node.js"
     },

--- a/packages/fetch/rollup.config.js
+++ b/packages/fetch/rollup.config.js
@@ -1,18 +1,35 @@
 import {builtinModules} from 'module';
 import {dependencies} from './package.json';
 
-export default {
-	input: 'src/lib.node.js',
-	output: {
-		file: 'dist/lib.node.cjs',
-		format: 'cjs',
-		esModule: false,
-		interop: false,
-		sourcemap: true,
-		preferConst: true,
-		exports: 'named',
-		// https://github.com/rollup/rollup/issues/1961#issuecomment-534977678
-		outro: 'exports = module.exports = Object.assign(fetch, exports);'
+export default [
+	{
+		input: 'src/lib.js',
+		output: {
+			file: 'dist/lib.cjs',
+			format: 'cjs',
+			esModule: false,
+			interop: false,
+			sourcemap: true,
+			preferConst: true,
+			exports: 'named',
+			// https://github.com/rollup/rollup/issues/1961#issuecomment-534977678
+			outro: 'exports = module.exports = Object.assign(fetch, exports);'
+		},
+		external: [...builtinModules, ...Object.keys(dependencies)]
 	},
-	external: [...builtinModules, ...Object.keys(dependencies)]
-};
+	{
+		input: 'src/lib.node.js',
+		output: {
+			file: 'dist/lib.node.cjs',
+			format: 'cjs',
+			esModule: false,
+			interop: false,
+			sourcemap: true,
+			preferConst: true,
+			exports: 'named',
+			// https://github.com/rollup/rollup/issues/1961#issuecomment-534977678
+			outro: 'exports = module.exports = Object.assign(fetch, exports);'
+		},
+		external: [...builtinModules, ...Object.keys(dependencies)]
+	},
+];

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -24,7 +24,10 @@
   "exports": {
     ".": {
       "types": "./dist/src/lib.d.ts",
-      "browser": "./src/lib.js",
+      "browser": {
+        "require": "./dist/src/lib.cjs",
+        "import": "./src/lib.js"
+      },
       "require": "./dist/src/lib.node.cjs",
       "node": "./src/lib.node.js"
     }

--- a/packages/form-data/package.json
+++ b/packages/form-data/package.json
@@ -22,7 +22,10 @@
   "exports": {
     ".": {
       "types": "./dist/src/lib.d.ts",
-      "browser": "./src/lib.js",
+      "browser": {
+        "require": "./dist/src/lib.cjs",
+        "import": "./src/lib.js"
+      },
       "require": "./dist/src/lib.node.cjs",
       "import": "./src/lib.node.js"
     }

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -24,7 +24,10 @@
   "exports": {
     ".": {
       "types": "./src/lib.d.ts",
-      "browser": "./src/lib.js",
+      "browser": {
+        "require": "./src/stream.cjs",
+        "import": "./src/lib.js"
+      },
       "require": "./src/stream.cjs",
       "import": "./src/lib.node.js"
     }


### PR DESCRIPTION
Just like @SimonB did with https://github.com/uuidjs/uuid/pull/616

This will remove the necessity of having all the packages in `transformIgnorePatterns` in https://github.com/remix-run/remix/pull/7220 or having them in `moduleNameMapper` in  https://github.com/remix-run/react-router/pull/9895

---

Closes #11
Closes https://github.com/remix-run/remix/issues/3402