### PR TITLE
POC to replace Headers with headers-polyfill

### DIFF
--- a/.changeset/light-radios-divide.md
+++ b/.changeset/light-radios-divide.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/web-fetch": major
+---
+
+Replace spec-incompliant `Headers` polyfill with spec-compliant `headers-polyfill`

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -105,6 +105,7 @@
     "@web3-storage/multipart-parser": "^1.0.0",
     "abort-controller": "^3.0.0",
     "data-uri-to-buffer": "^3.0.1",
+    "headers-polyfill": "^3.2.3",
     "mrmime": "^1.0.0"
   },
   "esm": {

--- a/packages/fetch/src/headers.js
+++ b/packages/fetch/src/headers.js
@@ -4,9 +4,8 @@
  * Headers class offers convenient helpers
  */
 
-import {types} from 'util';
 import http from 'http';
-import { isIterable } from './utils/is.js'
+import { Headers as HeadersPolyfill } from 'headers-polyfill';
 
 const validators = /** @type {{validateHeaderName?:(name:string) => any, validateHeaderValue?:(name:string, value:string) => any}} */
 (http)
@@ -39,246 +38,12 @@ const validateHeaderValue = typeof validators.validateHeaderValue === 'function'
 	};
 
 /**
- * @typedef {Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<Iterable<string>>} HeadersInit
+ *  @typedef {import("headers-polyfill").HeadersObject} HeadersObject
+ *  @typedef {import("headers-polyfill").HeadersList} HeadersList
+ *  @typedef {Headers | HeadersObject | HeadersList} HeadersInit
  */
 
-/**
- * This Fetch API interface allows you to perform various actions on HTTP request and response headers.
- * These actions include retrieving, setting, adding to, and removing.
- * A Headers object has an associated header list, which is initially empty and consists of zero or more name and value pairs.
- * You can add to this using methods like append() (see Examples.)
- * In all methods of this interface, header names are matched by case-insensitive byte sequence.
- *
- * @implements {globalThis.Headers}
- */
-export default class Headers extends URLSearchParams {
-	/**
-	 * Headers class
-	 *
-	 * @constructor
-	 * @param {HeadersInit} [init] - Response headers
-	 */
-	constructor(init) {
-		// Validate and normalize init object in [name, value(s)][]
-		/** @type {string[][]} */
-		let result = [];
-		if (init instanceof Headers) {
-			const raw = init.raw();
-			for (const [name, values] of Object.entries(raw)) {
-				result.push(...values.map(value => [name, value]));
-			}
-		} else if (init == null) { // eslint-disable-line no-eq-null, eqeqeq
-			// No op
-		} else if (isIterable(init)) {
-			// Sequence<sequence<ByteString>>
-			// Note: per spec we have to first exhaust the lists then process them
-			result = [...init]
-				.map(pair => {
-					if (
-						typeof pair !== 'object' || types.isBoxedPrimitive(pair)
-					) {
-						throw new TypeError('Each header pair must be an iterable object');
-					}
-
-					return [...pair];
-				}).map(pair => {
-					if (pair.length !== 2) {
-						throw new TypeError('Each header pair must be a name/value tuple');
-					}
-
-					return [...pair];
-				});
-		} else if (typeof init === "object" && init !== null) {
-			// Record<ByteString, ByteString>
-			result.push(...Object.entries(init));
-		} else {
-			throw new TypeError('Failed to construct \'Headers\': The provided value is not of type \'(sequence<sequence<ByteString>> or record<ByteString, ByteString>)');
-		}
-
-		// Validate and lowercase
-		result =
-			result.length > 0 ?
-				result.map(([name, value]) => {
-					validateHeaderName(name);
-					validateHeaderValue(name, String(value));
-					return [String(name).toLowerCase(), String(value)];
-				}) :
-				[];
-
-		super(result);
-
-		// Returning a Proxy that will lowercase key names, validate parameters and sort keys
-		// eslint-disable-next-line no-constructor-return
-		return new Proxy(this, {
-			get(target, p, receiver) {
-				switch (p) {
-					case 'append':
-					case 'set':
-						/**
-						 * @param {string} name
-						 * @param {string} value
-						 */
-						return (name, value) => {
-							validateHeaderName(name);
-							validateHeaderValue(name, String(value));
-							return URLSearchParams.prototype[p].call(
-								target,
-								String(name).toLowerCase(),
-								String(value)
-							);
-						};
-
-					case 'delete':
-					case 'has':
-					case 'getAll':
-						/**
-						 * @param {string} name
-						 */
-						return name => {
-							validateHeaderName(name);
-							// @ts-ignore
-							return URLSearchParams.prototype[p].call(
-								target,
-								String(name).toLowerCase()
-							);
-						};
-
-					case 'keys':
-						return () => {
-							target.sort();
-							return new Set(URLSearchParams.prototype.keys.call(target)).keys();
-						};
-
-					default:
-						return Reflect.get(target, p, receiver);
-				}
-			}
-			/* c8 ignore next */
-		});
-	}
-
-	get [Symbol.toStringTag]() {
-		return this.constructor.name;
-	}
-
-	toString() {
-		return Object.prototype.toString.call(this);
-	}
-
-	/**
-	 *
-	 * @param {string} name
-	 */
-	get(name) {
-		const values = this.getAll(name);
-		if (values.length === 0) {
-			return null;
-		}
-
-		let value = values.join(', ');
-		if (/^content-encoding$/i.test(name)) {
-			value = value.toLowerCase();
-		}
-
-		return value;
-	}
-
-	/**
-	 * @param {(value: string, key: string, parent: this) => void} callback
-	 * @param {any} thisArg
-	 * @returns {void}
-	 */
-	forEach(callback, thisArg = undefined) {
-		for (const name of this.keys()) {
-			if (name.toLowerCase() === 'set-cookie') {
-				let cookies = this.getAll(name);
-				while (cookies.length > 0) {
-					Reflect.apply(callback, thisArg, [cookies.shift(), name, this])
-				}
-			} else {
-				Reflect.apply(callback, thisArg, [this.get(name), name, this]);
-			}
-		}
-	}
-
-	/**
-	 * @returns {IterableIterator<string>}
-	 */
-	* values() {
-		for (const name of this.keys()) {
-			if (name.toLowerCase() === 'set-cookie') {
-				let cookies = this.getAll(name);
-				while (cookies.length > 0) {
-					yield /** @type {string} */(cookies.shift());
-				}
-			} else {
-				yield /** @type {string} */(this.get(name));
-			}
-		}
-	}
-
-	/**
-	 * @returns {IterableIterator<[string, string]>}
-	 */
-	* entries() {
-		for (const name of this.keys()) {
-			if (name.toLowerCase() === 'set-cookie') {
-				let cookies = this.getAll(name);
-				while (cookies.length > 0) {
-					yield [name, /** @type {string} */(cookies.shift())];
-				}
-			} else {
-				yield [name, /** @type {string} */(this.get(name))];
-			}
-		}
-	}
-
-	[Symbol.iterator]() {
-		return this.entries();
-	}
-
-	/**
-	 * Node-fetch non-spec method
-	 * returning all headers and their values as array
-	 * @returns {Record<string, string[]>}
-	 */
-	raw() {
-		return [...this.keys()].reduce((result, key) => {
-			result[key] = this.getAll(key);
-			return result;
-		}, /** @type {Record<string, string[]>} */({}));
-	}
-
-	/**
-	 * For better console.log(headers) and also to convert Headers into Node.js Request compatible format
-	 */
-	[Symbol.for('nodejs.util.inspect.custom')]() {
-		return [...this.keys()].reduce((result, key) => {
-			const values = this.getAll(key);
-			// Http.request() only supports string as Host header.
-			// This hack makes specifying custom Host header possible.
-			if (key === 'host') {
-				result[key] = values[0];
-			} else {
-				result[key] = values.length > 1 ? values : values[0];
-			}
-
-			return result;
-		}, /** @type {Record<string, string|string[]>} */({}));
-	}
-}
-
-/**
- * Re-shaping object for Web IDL tests
- * Only need to do it for overridden methods
- */
-Object.defineProperties(
-	Headers.prototype,
-	['get', 'entries', 'forEach', 'values'].reduce((result, property) => {
-		result[property] = {enumerable: true};
-		return result;
-	}, /** @type {Record<string, {enumerable:true}>} */ ({}))
-);
+export default HeadersPolyfill;
 
 /**
  * Create a Headers object from an http.IncomingMessage.rawHeaders, ignoring those that do
@@ -286,25 +51,23 @@ Object.defineProperties(
  * @param {import('http').IncomingMessage['rawHeaders']} headers
  */
 export function fromRawHeaders(headers = []) {
-	return new Headers(
-		headers
-			// Split into pairs
-			.reduce((result, value, index, array) => {
-				if (index % 2 === 0) {
-					result.push(array.slice(index, index + 2));
-				}
-
-				return result;
-			}, /** @type {string[][]} */([]))
-			.filter(([name, value]) => {
-				try {
-					validateHeaderName(name);
-					validateHeaderValue(name, String(value));
-					return true;
-				} catch {
-					return false;
-				}
-			})
-
-	);
+	let init = headers
+    // Split into pairs
+    .reduce((result, _, index, array) => {
+    	if (index % 2 === 0) {
+    		let [k, v] = array.slice(index, index + 2);
+    		result.push([k, v]);
+    	}
+    	return result;
+    }, /** @type {[string, string][]} */([]))
+    .filter(([name, value]) => {
+    	try {
+    		validateHeaderName(name);
+    		validateHeaderValue(name, String(value));
+    		return true;
+    	} catch {
+    		return false;
+    	}
+    });
+	return new HeadersPolyfill(init);
 }

--- a/packages/fetch/src/headers.js
+++ b/packages/fetch/src/headers.js
@@ -51,23 +51,24 @@ export default HeadersPolyfill;
  * @param {import('http').IncomingMessage['rawHeaders']} headers
  */
 export function fromRawHeaders(headers = []) {
-	let init = headers
-    // Split into pairs
-    .reduce((result, _, index, array) => {
-    	if (index % 2 === 0) {
-    		let [k, v] = array.slice(index, index + 2);
-    		result.push([k, v]);
-    	}
-    	return result;
-    }, /** @type {[string, string][]} */([]))
-    .filter(([name, value]) => {
-    	try {
-    		validateHeaderName(name);
-    		validateHeaderValue(name, String(value));
-    		return true;
-    	} catch {
-    		return false;
-    	}
-    });
-	return new HeadersPolyfill(init);
+	return new HeadersPolyfill(
+		headers
+			// Split into pairs
+			.reduce((result, value, index, array) => {
+				if (index % 2 === 0) {
+					let [k, v] = array.slice(index, index + 2);
+					result.push([k, v]);
+				}
+				return result;
+			}, /** @type {[string, string][]} */([]))
+			.filter(([name, value]) => {
+				try {
+					validateHeaderName(name);
+					validateHeaderValue(name, String(value));
+					return true;
+				} catch {
+					return false;
+				}
+			})
+	);
 }

--- a/packages/fetch/src/request.js
+++ b/packages/fetch/src/request.js
@@ -330,8 +330,7 @@ export const getNodeRequestOptions = request => {
 		query: parsedURL.query,
 		href: parsedURL.href,
 		method: request.method,
-		// @ts-ignore - not sure what this supposed to do
-		headers: headers[Symbol.for('nodejs.util.inspect.custom')](),
+		headers: headers.raw(),
 		insecureHTTPParser: request.insecureHTTPParser,
 		agent
 	};

--- a/packages/fetch/src/utils/is.js
+++ b/packages/fetch/src/utils/is.js
@@ -110,10 +110,3 @@ export const isReadableStream = (value) => {
 		typeof value.tee === "function"
 	);
 };
-
-/**
- *
- * @param {any} value
- * @returns {value is Iterable<unknown>}
- */
-export const isIterable = (value) => value && Symbol.iterator in value;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3474,6 +3474,11 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+headers-polyfill@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-3.2.3.tgz#ac656b4415b83f989fea3595931399fe9f055c7e"
+  integrity sha512-oj6MO8sdFQ9gQQedSVdMGh96suxTNp91vPQu7C4qx/57FqYsA5TiNr92nhIZwVQq8zygn4nu3xS1aEqpakGqdw==
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
POC to see if we could replace our `Headers` polyfill with [`headers-polyfill`](https://github.com/mswjs/headers-polyfill) which is more spec-compliant.  Our current polyfill (inherited when we forked this repo) implements the polyfill as `class Headers extends URLSearchParams` so that it can use `URLSearchParams` as an underlying store.  While convenient, this is incorrect because it inherits a handful of fields from `URLSearchParams` which should not be in headers.

Closes https://github.com/remix-run/remix/issues/7067