### PR TITLE
Revert "fix: Remove content-encoding header from already decompressed responses"

### DIFF
--- a/.changeset/dirty-moles-exercise.md
+++ b/.changeset/dirty-moles-exercise.md
@@ -1,5 +1,0 @@
----
-"@remix-run/web-fetch": patch
----
-
-fix: Remove content-encoding header from already decompressed responses. This eases the use of fetch in senarios where you wish to use it as a sort of makeshift proxy.

--- a/packages/fetch/src/fetch.js
+++ b/packages/fetch/src/fetch.js
@@ -277,7 +277,6 @@ async function fetch(url, options_ = {}) {
 
 			// For gzip
 			if (codings === 'gzip' || codings === 'x-gzip') {
-				responseOptions.headers.delete("Content-Encoding");
 				body = pump(body, zlib.createGunzip(zlibOptions), reject);
 				response = new Response(fromAsyncIterable(body), responseOptions);
 				resolve(response);
@@ -286,7 +285,6 @@ async function fetch(url, options_ = {}) {
 
 			// For deflate
 			if (codings === 'deflate' || codings === 'x-deflate') {
-				responseOptions.headers.delete("Content-Encoding");
 				// Handle the infamous raw deflate response from old servers
 				// a hack for old IIS and Apache servers
 				const raw = pump(response_, new PassThrough(), reject);
@@ -306,7 +304,6 @@ async function fetch(url, options_ = {}) {
 
 			// For br
 			if (codings === 'br') {
-				responseOptions.headers.delete("Content-Encoding");
 				body = pump(body, zlib.createBrotliDecompress(), reject);
 				response = new Response(fromAsyncIterable(body), responseOptions);
 				resolve(response);

--- a/packages/fetch/test/main.js
+++ b/packages/fetch/test/main.js
@@ -818,7 +818,6 @@ describe("node-fetch", () => {
 		const url = `${base}gzip`;
 		return fetch(url).then((res) => {
 			expect(res.headers.get("content-type")).to.equal("text/plain");
-			expect(res.headers.get("content-encoding")).to.be.null;
 			return res.text().then((result) => {
 				expect(result).to.be.a("string");
 				expect(result).to.equal("hello world");
@@ -837,9 +836,10 @@ describe("node-fetch", () => {
 		});
 	});
 
-	it("should decompress capitalised Content-Encoding", () => {
+	it("should make capitalised Content-Encoding lowercase", () => {
 		const url = `${base}gzip-capital`;
 		return fetch(url).then((res) => {
+			expect(res.headers.get("content-encoding")).to.equal("gzip");
 			return res.text().then((result) => {
 				expect(result).to.be.a("string");
 				expect(result).to.equal("hello world");
@@ -851,7 +851,6 @@ describe("node-fetch", () => {
 		const url = `${base}deflate`;
 		return fetch(url).then((res) => {
 			expect(res.headers.get("content-type")).to.equal("text/plain");
-			expect(res.headers.get("content-encoding")).to.be.null;
 			return res.text().then((result) => {
 				expect(result).to.be.a("string");
 				expect(result).to.equal("hello world");
@@ -878,7 +877,6 @@ describe("node-fetch", () => {
 		const url = `${base}brotli`;
 		return fetch(url).then((res) => {
 			expect(res.headers.get("content-type")).to.equal("text/plain");
-			expect(res.headers.get("content-encoding")).to.be.null;
 			return res.text().then((result) => {
 				expect(result).to.be.a("string");
 				expect(result).to.equal("hello world");
@@ -908,7 +906,6 @@ describe("node-fetch", () => {
 		const url = `${base}sdch`;
 		return fetch(url).then((res) => {
 			expect(res.headers.get("content-type")).to.equal("text/plain");
-			expect(res.headers.get("content-encoding")).to.equal("sdch");
 			return res.text().then((result) => {
 				expect(result).to.be.a("string");
 				expect(result).to.equal("fake sdch string");
@@ -960,7 +957,6 @@ describe("node-fetch", () => {
 		};
 		return fetch(url, options).then((res) => {
 			expect(res.headers.get("content-type")).to.equal("text/plain");
-			expect(res.headers.get("content-encoding")).to.equal("gzip");
 			return res.text().then((result) => {
 				expect(result).to.be.a("string");
 				expect(result).to.not.equal("hello world");


### PR DESCRIPTION
Reverts remix-run/web-std-io#54