### PR TITLE
fix(CI): stop testing on Node 14

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        node: [14, 16, 18, 20]
+        node: [16, 18, 20]
         os: [ubuntu-latest, windows-latest, macos-latest]
         project: [blob, fetch, file, form-data, stream]
 


### PR DESCRIPTION
CI is failing due to Node 14 tests

https://github.com/remix-run/web-std-io/actions/runs/14304822528/job/40086283075